### PR TITLE
Set intent for launch url to prevent crash

### DIFF
--- a/app/src/main/java/io/gonative/android/OneSignalNotificationHandler.java
+++ b/app/src/main/java/io/gonative/android/OneSignalNotificationHandler.java
@@ -32,6 +32,7 @@ public class OneSignalNotificationHandler implements OneSignal.NotificationOpene
         String launchUrl = notification.payload.launchURL;
         if (launchUrl != null && !launchUrl.isEmpty()) {
             Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(launchUrl));
+            intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
             context.startActivity(intent);
             return;
         }


### PR DESCRIPTION
Push messages which contain a launch url causes the app to crash on samsung SM-A500FU

Setting the intent flag fixes this.
See https://github.com/OneSignal/OneSignal-Android-SDK/issues/199

Device: Samsung Galaxy A5
Android version 6.0.1
Stack trace of crash

`
D/AndroidRuntime: Shutting down VM
E/AndroidRuntime: FATAL EXCEPTION: main
    Process: com.profixio.myprofixio.dev.debug, PID: 23397
    java.lang.RuntimeException: Unable to start receiver com.onesignal.NotificationOpenedReceiver: android.util.AndroidRuntimeException: Calling startActivity() from outside of an Activity  context requires the FLAG_ACTIVITY_NEW_TASK flag. Is this really what you want?
        at android.app.ActivityThread.handleReceiver(ActivityThread.java:3707)
        at android.app.ActivityThread.access$2000(ActivityThread.java:229)
        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1903)
        at android.os.Handler.dispatchMessage(Handler.java:102)
        at android.os.Looper.loop(Looper.java:148)
        at android.app.ActivityThread.main(ActivityThread.java:7331)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:1230)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1120)
     Caused by: android.util.AndroidRuntimeException: Calling startActivity() from outside of an Activity  context requires the FLAG_ACTIVITY_NEW_TASK flag. Is this really what you want?
        at android.app.ContextImpl.startActivity(ContextImpl.java:747)
        at android.app.ContextImpl.startActivity(ContextImpl.java:734)
        at android.content.ContextWrapper.startActivity(ContextWrapper.java:345)
        at io.gonative.android.OneSignalNotificationHandler.notificationOpened(OneSignalNotificationHandler.java:36)
`