### PR TITLE
added custom code execution bridge

### DIFF
--- a/app/src/main/java/io/gonative/android/JsCustomCodeExecutor.java
+++ b/app/src/main/java/io/gonative/android/JsCustomCodeExecutor.java
@@ -1,0 +1,64 @@
+package io.gonative.android;
+
+import android.util.Log;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.Map;
+
+public class JsCustomCodeExecutor {
+    private static final String TAG = JsCustomCodeExecutor.class.getName();
+
+    public static interface CustomCodeHandler {
+        JSONObject execute(Map<String, String> params);
+    }
+
+    // The default CustomCodeHandler "Echo"
+    // Simply maps all the key/values of the given params into a JSONObject
+    private static CustomCodeHandler handler = new CustomCodeHandler() {
+        @Override
+        public JSONObject execute(Map<String, String> params) {
+            if(params != null) {
+                JSONObject json = new JSONObject();
+                try {
+                    for(Map.Entry<String, String> entry : params.entrySet()) {
+                        json.put(entry.getKey(), entry.getValue());
+                    }
+                }
+                catch(JSONException e) {
+                    Log.e(TAG, "Error building custom Json Data", e);
+                }
+                return json;
+            }
+            return null;
+        }
+    };
+
+    /**
+     * Set new CustomCodeHandler to override the default "Echo" handler
+     * @param customHandler
+     */
+    public static void setHandler(CustomCodeHandler customHandler) {
+        if(customHandler == null)
+            return;
+        handler = customHandler;
+    }
+
+    /**
+     * Code Handler gets triggered by the UrlNavigation class
+     *
+     * @param params A map consisting of all URI parameters and their values
+     * @return A JSONObject as defined by the Code Handler
+     *
+     * @see UrlNavigation#shouldOverrideUrlLoading
+     */
+    public static JSONObject execute(Map<String, String> params) {
+        try {
+            return handler.execute(params);
+        } catch(Exception e) {
+            Log.e(TAG, "Error executing custom code", e);
+            return null;
+        }
+    }
+}

--- a/app/src/main/java/io/gonative/android/JsCustomCodeExecutor.java
+++ b/app/src/main/java/io/gonative/android/JsCustomCodeExecutor.java
@@ -1,0 +1,64 @@
+package io.gonative.android;
+
+import android.util.Log;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.Map;
+
+public class JsCustomCodeExecutor {
+    private static final String TAG = JsCustomCodeExecutor.class.getName();
+
+    public static interface CustomCodeHandler {
+        JSONObject execute(Map<String, String> params);
+    }
+
+    // The default CustomCodeHandler "Echo"
+    // Simply maps all the key/values of the given params into a JSONObject
+    private static CustomCodeHandler handler = new CustomCodeHandler() {
+        @Override
+        public JSONObject execute(Map<String, String> params) {
+            if(params != null) {
+                JSONObject json = new JSONObject();
+                try {
+                    for(Map.Entry<String, String> entry : params.entrySet()) {
+                        json.put(entry.getKey(), entry.getValue());
+                    }
+                }
+                catch(JSONException e) {
+                    Log.e(TAG, "Error building custom Json Data", e);
+                }
+                return json;
+            }
+            return null;
+        }
+    };
+
+    /**
+     * Set new CustomCodeHandler to override the default "Echo" handler
+     * @param customHandler
+     */
+    public static void setHandler(CustomCodeHandler customHandler) {
+        if(handler == null)
+            return;
+        handler = customHandler;
+    }
+
+    /**
+     * Code Handler gets triggered by the UrlNavigation class
+     *
+     * @param params A map consisting of all URI parameters and their values
+     * @return A JSONObject mapping the key/values of the given <code>params</code>
+     *
+     * @see UrlNavigation#shouldOverrideUrlLoading
+     */
+    public static JSONObject execute(Map<String, String> params) {
+        try {
+            return handler.execute(params);
+        } catch(Exception e) {
+            Log.e(TAG, "Error executing custom code", e);
+            return null;
+        }
+    }
+}

--- a/app/src/main/java/io/gonative/android/UrlNavigation.java
+++ b/app/src/main/java/io/gonative/android/UrlNavigation.java
@@ -59,6 +59,7 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Currency;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
@@ -241,6 +242,29 @@ public class UrlNavigation {
                         }
                     } catch (Exception e) {
                         Log.e(TAG, "Error calling gonative://nativebridge/multi", e);
+                    }
+                } else if("/custom".equals(uri.getPath())) {
+                    Map<String, String> params = new HashMap<String, String>();
+                    for(String parameterName : uri.getQueryParameterNames()) {
+                        String parameter = uri.getQueryParameter(parameterName);
+                        params.put(parameterName, parameter);
+                    }
+
+                    // execute code defined by the CustomCodeHandler
+                    // call JsCustomCodeExecutor#setHandler to override this default handler
+                    JSONObject data = JsCustomCodeExecutor.execute(params);
+
+                    String callback = params.get("callback");
+                    if(callback != null && !callback.isEmpty()) {
+                        final String js = LeanUtils.createJsForCallback(callback, data);
+                        // run on main thread
+                        Handler mainHandler = new Handler(mainActivity.getMainLooper());
+                        mainHandler.post(new Runnable() {
+                            @Override
+                            public void run() {
+                                mainActivity.runJavascript(js);
+                            }
+                        });
                     }
                 }
                 return true;


### PR DESCRIPTION
I've added a section to UrlNavigation to evaluate our new "custom" path.

When called with no callback function, the code within the currently set CustomCodeHandler gets executed and nothing is reported back. The additional query parameters get passed to the currently set CustomCodeHandler as a HashMap<String, String> to allow further control.

e.g: gonative://nativebridge/custom?dataone=CustomDataString1&datatwo=CustomDataString2


When called with a callback function the behavior is exactly the same except the result the currently set CustomCodeHandler produces is reported back as a JSONObject. If no result is produced, the callback function is still called but won't be given any data.

e.g: gonative://nativebridge/custom?callback=customCallbackFunction&dataone=CustomDataString1&datatwo=CustomDataString2


To demonstrate this, the default CustomCodeHandler simply takes all given query parameters and returns them as a JSONObject.